### PR TITLE
chore: CI 에러 fix -#13

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -31,6 +31,5 @@ jobs:
       # 4) Gradle 사용. arguments 를 붙이면 뒤에 그대로 실행된다고 생각하면 됨
       # 이 워크플로우는 gradle clean build 를 수행함
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee
-        with:
-          arguments: clean build
+        run: ./gradlew clean build -x test
+        shell: bash

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -23,7 +23,12 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      # 3) Gradle 사용. arguments 를 붙이면 뒤에 그대로 실행된다고 생각하면 됨
+      # 3)권한 부여 >> 리눅스 명령어다
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+        shell: bash
+
+      # 4) Gradle 사용. arguments 를 붙이면 뒤에 그대로 실행된다고 생각하면 됨
       # 이 워크플로우는 gradle clean build 를 수행함
       - name: Build with Gradle
         uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee


### PR DESCRIPTION
## Description
CI 에서 Error: Gradle script '/home/runner/work/Backend/Backend/gradlew' is not executable. 에러 발생
## Changes
### 변경 사항 제목
- [x] dev_deploy.yml 에 권한 부여하는 리눅스 명령어 추가 (코드의 3번 부분)
- [x] dev_deploy.yml 의 build 명령어 수정 (코드의 4번 부분)
## API
X
## Additional context
X

