### PR TITLE
feat: 참여코드로 그룹 참여 -#11

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -28,8 +28,7 @@ jobs:
         run: chmod +x ./gradlew
         shell: bash
 
-      # 4) Gradle 사용. arguments 를 붙이면 뒤에 그대로 실행된다고 생각하면 됨
-      # 이 워크플로우는 gradle clean build 를 수행함
+      # 4) .build시작 >> 리눅스 명령어다. 6,7번 내용은 어지간해서 바뀌지 않는다.
       - name: Build with Gradle
         run: ./gradlew clean build -x test
         shell: bash

--- a/src/main/java/go/alarm/domain/entity/UserGroup.java
+++ b/src/main/java/go/alarm/domain/entity/UserGroup.java
@@ -38,6 +38,8 @@ public class UserGroup extends BaseEntity{
 
     private Boolean isWakeup;
 
+    private Boolean isAgree; // 전화번호 사용 동의 여부
+
     public void setGroup(Group group){
         if (this.group != null)
             group.getUserGroupList().remove(this);

--- a/src/main/java/go/alarm/domain/repository/GroupRepository.java
+++ b/src/main/java/go/alarm/domain/repository/GroupRepository.java
@@ -4,4 +4,5 @@ import go.alarm.domain.entity.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
+    Group findByParticipationCode(String participationCode);
 }

--- a/src/main/java/go/alarm/service/GroupService.java
+++ b/src/main/java/go/alarm/service/GroupService.java
@@ -1,11 +1,15 @@
 package go.alarm.service;
 
 import go.alarm.domain.entity.Group;
+import go.alarm.domain.entity.UserGroup;
 import go.alarm.web.dto.GroupRequestDTO;
 
-public interface GroupCommandService {
+public interface GroupService {
 
     Group createGroup(Long userId, GroupRequestDTO.CreateDTO request);
 
     Group createMemo(Long userId, Long storeId, GroupRequestDTO.CreateMemoDTO request);
+
+    UserGroup joinGroup(Long userId, GroupRequestDTO.JoinGroupDTO request);
+
 }

--- a/src/main/java/go/alarm/service/GroupServiceImpl.java
+++ b/src/main/java/go/alarm/service/GroupServiceImpl.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional//@Transactional(readOnly = true) 여기 readOnly=true가 되니까 권한이 읽기 권한만 존재함.
-public class GroupCommandServiceImpl implements GroupCommandService{
+public class GroupServiceImpl implements GroupService {
 
     private final GroupRepository groupRepository;
     private final UserRepository userRepository;
@@ -29,7 +29,7 @@ public class GroupCommandServiceImpl implements GroupCommandService{
         WakeupDate wakeupDate = WakeupDateConverter.toWakeupDate(group, request.getWakeupDateList()); // 기상 요일 설정
         group.setWakeupDate(wakeupDate);
 
-        UserGroup userGroup = UserGroupConverter.toUserGroup(userRepository.findById(userId).get()); // 유저 그룹 생성
+        UserGroup userGroup = UserGroupConverter.toUserGroup(userRepository.findById(userId).get(), request.getIsAgree()); // 유저 그룹 생성
         System.out.println("group = " + group.getUserGroupList());
         userGroup.setGroup(group); // userGroup을 userGroupRepository.save로 저장해야 하나..?
         // 아니다. setGroup을 들어가보면 group.~~.add로 userGroup객체를 넣어준다.
@@ -53,5 +53,18 @@ public class GroupCommandServiceImpl implements GroupCommandService{
         group.setMemo(request.getMemo());
         System.out.println(request.getMemo());
         return group;
+    }
+
+    @Override
+    public UserGroup joinGroup(Long userId, GroupRequestDTO.JoinGroupDTO request) {
+        Group group = groupRepository.findByParticipationCode(request.getParticipationCode()); // 참여 코드로 그룹 찾기
+        // 참여 코드가 없을 시 예외 처리도 해줘야 함.
+        // 유저가 존재하는 지 예외 처리 해줘야 함.
+
+        UserGroup userGroup = UserGroupConverter.toUserGroup(userRepository.findById(userId).get(),request.getIsAgree()); // 유저 그룹 생성(그룹에 유저 넣기)
+        userGroup.setGroup(group);
+        // 그룹에 인원수가 다 찼다면 참여가 불가능한 예외 처리도 해줘야 함.
+
+        return userGroup;
     }
 }

--- a/src/main/java/go/alarm/web/controller/GroupController.java
+++ b/src/main/java/go/alarm/web/controller/GroupController.java
@@ -2,8 +2,10 @@ package go.alarm.web.controller;
 
 
 import go.alarm.domain.entity.Group;
+import go.alarm.domain.entity.User;
+import go.alarm.domain.entity.UserGroup;
 import go.alarm.response.BaseResponse;
-import go.alarm.service.GroupCommandService;
+import go.alarm.service.GroupService;
 import go.alarm.web.converter.GroupConverter;
 import go.alarm.web.dto.GroupRequestDTO;
 import go.alarm.web.dto.GroupResponseDTO;
@@ -25,25 +27,35 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class GroupController {
 
-    private final GroupCommandService groupCommandService;
+    private final GroupService groupService;
 
-    @PostMapping
+    @PostMapping// 그룹 생성 (= 알람 생성)
     public BaseResponse<GroupResponseDTO.CreateResultDto> CreateGroup
         (@RequestHeader(name = "userId") Long userId,
             @RequestBody @Valid GroupRequestDTO.CreateDTO request) {
 
-        Group group = groupCommandService.createGroup(userId, request);
+        Group group = groupService.createGroup(userId, request);
         return new BaseResponse<>(GroupConverter.toCreateResultDTO(group));
     }
 
-    @PostMapping("/{groupId}/memo")
+    @PostMapping("/{groupId}/memo") // 메모 생성
     public BaseResponse<GroupResponseDTO.CreateResultDto> CreateMemo
         (@RequestHeader(name = "userId") Long userId,
             @PathVariable(name = "groupId") Long groupId,
             @RequestBody @Valid GroupRequestDTO.CreateMemoDTO request) {
 
-        Group group = groupCommandService.createMemo(userId, groupId, request);
+        Group group = groupService.createMemo(userId, groupId, request);
         return new BaseResponse<>(GroupConverter.toCreateResultDTO(group));
+    }
+
+    @PostMapping("/{groupId}/join")// 참여 코드로 참여
+    public BaseResponse<GroupResponseDTO.JoinResultDto> JoinGroup
+        (@RequestHeader(name = "userId") Long userId,
+            @RequestBody @Valid GroupRequestDTO.JoinGroupDTO request) {
+
+        UserGroup userGroup = groupService.joinGroup(userId, request);
+
+        return new BaseResponse<>(GroupConverter.toJoinResultDTO(userGroup.getGroup(), userGroup.getUser()));
     }
 
 }

--- a/src/main/java/go/alarm/web/converter/GroupConverter.java
+++ b/src/main/java/go/alarm/web/converter/GroupConverter.java
@@ -1,6 +1,7 @@
 package go.alarm.web.converter;
 
 import go.alarm.domain.entity.Group;
+import go.alarm.domain.entity.User;
 import go.alarm.domain.entity.WakeupDate;
 import go.alarm.web.dto.GroupRequestDTO;
 import go.alarm.web.dto.GroupRequestDTO.CreateDTO;
@@ -11,17 +12,16 @@ import java.util.List;
 
 public class GroupConverter {
 
-    public static GroupResponseDTO.CreateResultDto toCreateResultDTO(Group Group){
+    public static GroupResponseDTO.CreateResultDto toCreateResultDTO(Group group){
         return GroupResponseDTO.CreateResultDto.builder()
-            .groupId(Group.getId())
+            .groupId(group.getId())
             .createdAt(LocalDateTime.now())
             .build();
     }
 
     public static Group toGroup(CreateDTO request){
 
-
-        int codeLength = 6;
+        int codeLength = 8;
 
         String AlphaNumericString = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "0123456789";
 
@@ -43,6 +43,14 @@ public class GroupConverter {
             // group.getUserGroupList()의 반환값이 null이 되는 것. 여기에 .add를 해버리니까 (null에 add를 하니까)
             // userGroupList에 NullPointerException이 일어남
             .participationCode(sb.toString())
+            .build();
+    }
+
+    public static GroupResponseDTO.JoinResultDto toJoinResultDTO(Group group, User user){
+        return GroupResponseDTO.JoinResultDto.builder()
+            .groupId(group.getId())
+            .joinUserNickname(user.getNickname())
+            .createdAt(LocalDateTime.now())
             .build();
     }
 }

--- a/src/main/java/go/alarm/web/converter/UserGroupConverter.java
+++ b/src/main/java/go/alarm/web/converter/UserGroupConverter.java
@@ -6,11 +6,12 @@ import go.alarm.domain.entity.UserGroup;
 
 public class UserGroupConverter {
 
-    public static UserGroup toUserGroup(User user){
+    public static UserGroup toUserGroup(User user, Boolean isAgree){
 
         return UserGroup.builder()
             .user(user)
             .phone(user.getPhone())
+            .isAgree(isAgree)
             .build();
     }
 

--- a/src/main/java/go/alarm/web/dto/GroupRequestDTO.java
+++ b/src/main/java/go/alarm/web/dto/GroupRequestDTO.java
@@ -18,10 +18,20 @@ public class GroupRequestDTO {
         String memo;
         @NotNull
         List<String> wakeupDateList;
+        @NotNull
+        Boolean isAgree;
     }
 
     @Getter
     public static class CreateMemoDTO{
         String memo;
+    }
+
+    @Getter
+    public static class JoinGroupDTO{
+        @NotNull
+        String participationCode;
+        @NotNull
+        Boolean isAgree;
     }
 }

--- a/src/main/java/go/alarm/web/dto/GroupResponseDTO.java
+++ b/src/main/java/go/alarm/web/dto/GroupResponseDTO.java
@@ -17,4 +17,14 @@ public class GroupResponseDTO {
         LocalDateTime createdAt;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class JoinResultDto{
+        Long groupId;
+        String joinUserNickname;
+        LocalDateTime createdAt;
+    }
+
 }


### PR DESCRIPTION
## Description
알람 그룹에 참여 코드로 참여 
## Changes
### 변경 사항 제목
- [x] 유저 그룹 엔티티에 isAgree 컬럼 추가하여 전화 번호 이용 동의 여부를 저장
- [x] service 단의 클래스, 인터페이스명 간단하게 수정
- [x] 그룹 생성할 때 그룹장의 전화번호 사용 가능 여부 입력받도록 수정

## API
| URL                | method | Usage                | Authorization Needed |
| ------------------ | ------ | -------------------- | -------------------- |
| /groups/{groupId}/join     | POST| 그룹에 참여| YES                    |
## Additional context
전화번호 사용 가능 여부도 함께 body로 받아옴
