### PR TITLE
refactor: 그룹 생성시 메모도 함께 작성

### DIFF
--- a/src/main/java/go/alarm/domain/repository/UserRepository.java
+++ b/src/main/java/go/alarm/domain/repository/UserRepository.java
@@ -4,4 +4,5 @@ import go.alarm.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    User findByPhone(String phone);
 }

--- a/src/main/java/go/alarm/service/GroupService.java
+++ b/src/main/java/go/alarm/service/GroupService.java
@@ -8,8 +8,8 @@ public interface GroupService {
 
     Group createGroup(Long userId, GroupRequestDTO.CreateDTO request);
 
-    Group createMemo(Long userId, Long storeId, GroupRequestDTO.CreateMemoDTO request);
-
     UserGroup joinGroup(Long userId, GroupRequestDTO.JoinGroupDTO request);
+
+    UserGroup inviteGroup(Long userId, Long groupId,GroupRequestDTO.InviteGroupDTO request);
 
 }

--- a/src/main/java/go/alarm/service/GroupServiceImpl.java
+++ b/src/main/java/go/alarm/service/GroupServiceImpl.java
@@ -1,6 +1,7 @@
 package go.alarm.service;
 
 import go.alarm.domain.entity.Group;
+import go.alarm.domain.entity.User;
 import go.alarm.domain.entity.UserGroup;
 import go.alarm.domain.entity.WakeupDate;
 import go.alarm.domain.repository.GroupRepository;
@@ -9,6 +10,7 @@ import go.alarm.web.converter.GroupConverter;
 import go.alarm.web.converter.UserGroupConverter;
 import go.alarm.web.converter.WakeupDateConverter;
 import go.alarm.web.dto.GroupRequestDTO;
+import go.alarm.web.dto.GroupRequestDTO.InviteGroupDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,26 +47,28 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
-    public Group createMemo(Long userId, Long groupId, GroupRequestDTO.CreateMemoDTO request) {
-
-        // userId를 통해 해당 유저가 이 그룹에 속해있는지 예외 처리를 이 서비스 단에서 하냐? 컨트롤러에서 하냐?
-        // 아니면 umc 워크북처럼 따로 예외처리 어노테이션을 만들어서 컨트롤러에서 하냐?는 나중에 정해야 할듯.
-        Group group = groupRepository.findById(groupId).get();
-        group.setMemo(request.getMemo());
-        System.out.println(request.getMemo());
-        return group;
-    }
-
-    @Override
     public UserGroup joinGroup(Long userId, GroupRequestDTO.JoinGroupDTO request) {
         Group group = groupRepository.findByParticipationCode(request.getParticipationCode()); // 참여 코드로 그룹 찾기
+        // 위에서 굳이 참여 코드로 그룹을 찾을 필요가 있나? Path Variable로 넘어온 그룹 Id를 통해서 하면 안됨?
+        // 참여 코드가 Path Variable로 넘어온 그룹 Id의 참여 코드인지 검증도 해줘야 함.
         // 참여 코드가 없을 시 예외 처리도 해줘야 함.
         // 유저가 존재하는 지 예외 처리 해줘야 함.
 
-        UserGroup userGroup = UserGroupConverter.toUserGroup(userRepository.findById(userId).get(),request.getIsAgree()); // 유저 그룹 생성(그룹에 유저 넣기)
+        UserGroup userGroup = UserGroupConverter.toUserGroup(userRepository.findById(userId).get(), request.getIsAgree()); // 유저 그룹 생성(그룹에 유저 넣기)
         userGroup.setGroup(group);
         // 그룹에 인원수가 다 찼다면 참여가 불가능한 예외 처리도 해줘야 함.
 
         return userGroup;
+    }
+
+    @Override
+    public UserGroup inviteGroup(Long userId, Long groupId, InviteGroupDTO request) {
+        Group group = groupRepository.findById(groupId).get(); // 그룹Id로 그룹 찾기
+        User sender = userRepository.findById(userId).get(); // 초대한 유저 찾기
+        User receiver = userRepository.findByPhone(request.getPhone()); // 전화번호로 초대받은 유저 찾기
+
+        // request.getPhone이 존재하는지 점검해야 함.
+
+        return null;
     }
 }

--- a/src/main/java/go/alarm/web/controller/GroupController.java
+++ b/src/main/java/go/alarm/web/controller/GroupController.java
@@ -38,16 +38,6 @@ public class GroupController {
         return new BaseResponse<>(GroupConverter.toCreateResultDTO(group));
     }
 
-    @PostMapping("/{groupId}/memo") // 메모 생성
-    public BaseResponse<GroupResponseDTO.CreateResultDto> CreateMemo
-        (@RequestHeader(name = "userId") Long userId,
-            @PathVariable(name = "groupId") Long groupId,
-            @RequestBody @Valid GroupRequestDTO.CreateMemoDTO request) {
-
-        Group group = groupService.createMemo(userId, groupId, request);
-        return new BaseResponse<>(GroupConverter.toCreateResultDTO(group));
-    }
-
     @PostMapping("/{groupId}/join")// 참여 코드로 참여
     public BaseResponse<GroupResponseDTO.JoinResultDto> JoinGroup
         (@RequestHeader(name = "userId") Long userId,
@@ -56,6 +46,18 @@ public class GroupController {
         UserGroup userGroup = groupService.joinGroup(userId, request);
 
         return new BaseResponse<>(GroupConverter.toJoinResultDTO(userGroup.getGroup(), userGroup.getUser()));
+    }
+
+    @PostMapping("/{groupId}/invite")// 전화번호로 유저 초대
+    public BaseResponse<GroupResponseDTO.InviteResultDto> InviteGroup
+        (@RequestHeader(name = "userId") Long userId,
+            @PathVariable(name = "groupId") Long groupId,
+            @RequestBody @Valid GroupRequestDTO.InviteGroupDTO request) {
+
+        UserGroup userGroup = groupService.inviteGroup(userId, groupId, request);
+
+       // return new BaseResponse<>(GroupConverter.toInviteResultDTO(userGroup.getGroup(), userGroup.getUser()));
+        return null; // 일단 보류
     }
 
 }

--- a/src/main/java/go/alarm/web/converter/GroupConverter.java
+++ b/src/main/java/go/alarm/web/converter/GroupConverter.java
@@ -43,6 +43,7 @@ public class GroupConverter {
             // group.getUserGroupList()의 반환값이 null이 되는 것. 여기에 .add를 해버리니까 (null에 add를 하니까)
             // userGroupList에 NullPointerException이 일어남
             .participationCode(sb.toString())
+            .memo(request.getMemo())
             .build();
     }
 

--- a/src/main/java/go/alarm/web/dto/GroupRequestDTO.java
+++ b/src/main/java/go/alarm/web/dto/GroupRequestDTO.java
@@ -15,22 +15,27 @@ public class GroupRequestDTO {
         String name;
         @NotNull
         LocalTime wakeupTime;
-        String memo;
         @NotNull
         List<String> wakeupDateList;
         @NotNull
         Boolean isAgree;
-    }
 
-    @Getter
-    public static class CreateMemoDTO{
         String memo;
     }
+
 
     @Getter
     public static class JoinGroupDTO{
         @NotNull
         String participationCode;
+        @NotNull
+        Boolean isAgree;
+    }
+
+    @Getter
+    public static class InviteGroupDTO{
+        @NotNull
+        String phone;
         @NotNull
         Boolean isAgree;
     }

--- a/src/main/java/go/alarm/web/dto/GroupResponseDTO.java
+++ b/src/main/java/go/alarm/web/dto/GroupResponseDTO.java
@@ -27,4 +27,15 @@ public class GroupResponseDTO {
         LocalDateTime createdAt;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InviteResultDto{
+        Long groupId;
+        String sender; // 초대한 사람
+        String receiver; // 초대받은 사람
+        LocalDateTime createdAt;
+    }
+
 }


### PR DESCRIPTION
## Description
그룹 생성시 메모를 함께 작성하도록 수정, 메모 작성 API 삭제
## Changes
### 변경 사항 제목
- [x] 그룹 생성과 동시에 메모 생성
- [x] 메모 작성 API 삭제
## API
| URL                | method | Usage                | Authorization Needed |
| ------------------ | ------ | -------------------- | -------------------- |
| /groups       | POST| 알람 그룹 생성| Yes                  |
## Additional context
기존: 그룹 생성 이후 메모 작성
수정 후: 그룹 생성과 동시에 메모 생성
