### PR TITLE
rename: 메인페이지 조회 API의 응답 객체명을 수정한다.

### DIFF
--- a/src/main/java/go/alarm/web/converter/MainConverter.java
+++ b/src/main/java/go/alarm/web/converter/MainConverter.java
@@ -14,7 +14,7 @@ public class MainConverter {
     public static MainResponseDTO.MainDTO mainDTO(String connectorProfileURL, List<MainResponseDTO.GroupDTO> groupDTOList) {
         return MainResponseDTO.MainDTO.builder()
             .connectorProfileURL(connectorProfileURL)
-            .groupDTOList(groupDTOList)
+            .groupList(groupDTOList)
             .listSize(groupDTOList.size())
             .build();
     }
@@ -27,7 +27,7 @@ public class MainConverter {
             .name(group.getName())
             .wakeupTime(group.getWakeupTime())
             .wakeupDateList(wakeupDateList)
-            .userDTOList(userDTOList)
+            .userList(userDTOList)
             .memo(group.getMemo())
             .build();
     }

--- a/src/main/java/go/alarm/web/dto/MainResponseDTO.java
+++ b/src/main/java/go/alarm/web/dto/MainResponseDTO.java
@@ -18,7 +18,7 @@ public class MainResponseDTO {
     @AllArgsConstructor
     public static class MainDTO{
         String connectorProfileURL; // 접속자의 프로필 이미지 URL
-        List<GroupDTO> groupDTOList;
+        List<GroupDTO> groupList;
         Integer listSize;
     }
 
@@ -31,7 +31,7 @@ public class MainResponseDTO {
         String name;
         LocalTime wakeupTime;
         List<String> wakeupDateList;
-        List<UserDTO> userDTOList;
+        List<UserDTO> userList;
         String memo;
     }
 


### PR DESCRIPTION
## Description
메인페이지 조회 API의 응답 객체명을 바꾼다.
## Changes
### 변경 사항 제목
- [x] mainDTO의 groupDTOList >> groupList
- [x] groupDTO의 userDTOList >> userList
## API
X
## Additional context
X
