### PR TITLE
Hot Fix: 그룹 수정시 group_id가 null이 되고 기상 요일이 수정되지 않는 부분을 해결한다.

### DIFF
--- a/src/main/java/go/alarm/domain/entity/Group.java
+++ b/src/main/java/go/alarm/domain/entity/Group.java
@@ -52,11 +52,6 @@ public class Group extends BaseEntity{
     }
 
     public void setWakeupDate(WakeupDate wakeupDate) {
-        if (this.wakeupDate != null) {
-            WakeupDate previousWakeupDate = this.wakeupDate;
-            this.wakeupDate = null;
-            previousWakeupDate.setGroup(null); // 1:1 관계에서 반대쪽 객체의 참조 해제
-        }
         this.wakeupDate = wakeupDate;
     }
 

--- a/src/main/java/go/alarm/domain/entity/WakeupDate.java
+++ b/src/main/java/go/alarm/domain/entity/WakeupDate.java
@@ -50,4 +50,43 @@ public class WakeupDate extends BaseEntity {
         }
         this.group = group;
     }
+
+    public void resetWakeupDate(){
+        this.mon = Boolean.FALSE;
+        this.tue = Boolean.FALSE;
+        this.wed = Boolean.FALSE;
+        this.thu = Boolean.FALSE;
+        this.fri = Boolean.FALSE;
+        this.sat = Boolean.FALSE;
+        this.sun = Boolean.FALSE;
+    }
+
+    // 아래처럼 하는 것이 맞으려나......?
+    public void setMon(Boolean mon) {
+        this.mon = mon;
+    }
+
+    public void setTue(Boolean tue) {
+        this.tue = tue;
+    }
+
+    public void setWed(Boolean wed) {
+        this.wed = wed;
+    }
+
+    public void setThu(Boolean thu) {
+        this.thu = thu;
+    }
+
+    public void setFri(Boolean fri) {
+        this.fri = fri;
+    }
+
+    public void setSat(Boolean sat) {
+        this.sat = sat;
+    }
+
+    public void setSun(Boolean sun) {
+        this.sun = sun;
+    }
 }

--- a/src/main/java/go/alarm/service/GroupServiceImpl.java
+++ b/src/main/java/go/alarm/service/GroupServiceImpl.java
@@ -1,7 +1,6 @@
 package go.alarm.service;
 
 import go.alarm.domain.entity.Group;
-import go.alarm.domain.entity.User;
 import go.alarm.domain.entity.UserGroup;
 import go.alarm.domain.entity.WakeupDate;
 import go.alarm.domain.repository.GroupRepository;
@@ -13,7 +12,6 @@ import go.alarm.web.converter.WakeupDateConverter;
 import go.alarm.web.dto.GroupRequestDTO;
 import go.alarm.web.dto.GroupRequestDTO.UpdateGroupDTO;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,11 +54,35 @@ public class GroupServiceImpl implements GroupService {
         Group group = groupRepository.findById(groupId).get();
 
         group.setWakeupTime(request.getWakeupTime());
-        group.setWakeupDate(group.getWakeupDate()); // 이 부분을 고쳐야 함.
+        updateWakeupDate(group.getWakeupDate(), request.getWakeupDateList());
         group.setName(request.getName());
         group.setMemo(request.getMemo());
 
         return group;
+    }
+
+    public WakeupDate updateWakeupDate(WakeupDate wakeupDate, List<String> wakeupDateList){
+        
+        wakeupDate.resetWakeupDate(); // 기존 기상 요일 리셋
+
+        for (String dayOfWeek : wakeupDateList) {
+            if (dayOfWeek.equals("mon")) {
+                wakeupDate.setMon(Boolean.TRUE);
+            } else if (dayOfWeek.equals("tue")) {
+                wakeupDate.setTue(Boolean.TRUE);
+            } else if (dayOfWeek.equals("wed")) {
+                wakeupDate.setWed(Boolean.TRUE);
+            } else if (dayOfWeek.equals("thu")) {
+                wakeupDate.setThu(Boolean.TRUE);
+            } else if (dayOfWeek.equals("fri")) {
+                wakeupDate.setFri(Boolean.TRUE);
+            } else if (dayOfWeek.equals("sat")) {
+                wakeupDate.setSat(Boolean.TRUE);
+            } else if (dayOfWeek.equals("sun")) {
+                wakeupDate.setSun(Boolean.TRUE);
+            }
+        }
+        return wakeupDate;
     }
 
     @Override

--- a/src/main/java/go/alarm/web/converter/WakeupDateConverter.java
+++ b/src/main/java/go/alarm/web/converter/WakeupDateConverter.java
@@ -9,11 +9,26 @@ public class WakeupDateConverter {
 
     public static WakeupDate toWakeupDate(Group group, List<String> wakeupDateList) {
 
+        WakeupDateResult wakeupDateResult = getWakeupDate(wakeupDateList);
+        return WakeupDate.builder()
+            .group(group)
+            .mon(wakeupDateResult.isMon())
+            .tue(wakeupDateResult.isTue())
+            .wed(wakeupDateResult.isWed())
+            .thu(wakeupDateResult.isThu())
+            .fri(wakeupDateResult.isFri())
+            .sat(wakeupDateResult.isSat())
+            .sun(wakeupDateResult.isSun())
+            .build();
+    }
+
+    private static WakeupDateResult getWakeupDate(List<String> wakeupDateList) {
         Boolean isMon = Boolean.FALSE,
             isTue = Boolean.FALSE, isWed = Boolean.FALSE,
             isThu = Boolean.FALSE, isFri = Boolean.FALSE,
             isSat = Boolean.FALSE, isSun = Boolean.FALSE;
 
+        // 이 부분을 메소드로 빼서 main컨버터랑 여기랑 같은 코드로 쓸 수도 있지 않을까?
         for (String dayOfWeek : wakeupDateList) {
             if (dayOfWeek.equals("mon")) {
                 isMon = Boolean.TRUE;
@@ -31,15 +46,10 @@ public class WakeupDateConverter {
                 isSun = Boolean.TRUE;
             }
         }
-        return WakeupDate.builder()
-            .group(group)
-            .mon(isMon)
-            .tue(isTue)
-            .wed(isWed)
-            .thu(isThu)
-            .fri(isFri)
-            .sat(isSat)
-            .sun(isSun)
-            .build();
+        WakeupDateResult wakeupDateResult = new WakeupDateResult(isMon, isTue, isWed, isThu, isFri, isSat, isSun);
+        return wakeupDateResult;
+    }
+
+    private record WakeupDateResult(Boolean isMon, Boolean isTue, Boolean isWed, Boolean isThu, Boolean isFri, Boolean isSat, Boolean isSun) {
     }
 }


### PR DESCRIPTION
## Description
1. 그룹(알람)을 수정했을 때, group_id가 null이 되고 WakeupDate가 수정되지 않는 부분을 Fix합니다.
## Changes
### 변경 사항 제목
- [x]  GroupServiceImpl의 그룹 수정 API 수정
- [x] WakeupDateConverter의 toWakeupDate 메소드의 내부 로직을 getWakeupDate메소드로 따로 빼줌.
- [x] WakeupDate의 각 요일별 Setter 생성
## API
| URL                | method | Usage                | Authorization Needed |
| ------------------ | ------ | -------------------- | -------------------- |
| /groups    | PATCH| 그룹 수정| YES                    |

## Additional context
1. 예외 처리는 추후 추가해야 함.
3. 🚑 그룹 수정시 group_id가 null이 됨. 🚑  >> 수정 완료
