### PR TITLE
fix: 취침 알림 시간 설정 API 버그를 수정한다

### DIFF
--- a/src/main/java/go/alarm/service/UserServiceImpl.java
+++ b/src/main/java/go/alarm/service/UserServiceImpl.java
@@ -32,7 +32,10 @@ public class UserServiceImpl implements UserService {
     @Override
     public User setBedTime(Long userId, UserRequestDTO.SetBedTimeDTO request) {
         User user = userRepository.findById(userId).get();
-        dayOfWeekRepository.delete(user.getBedDayOfWeek());
+
+        if(user.getBedDayOfWeek() != null){
+            dayOfWeekRepository.delete(user.getBedDayOfWeek());
+        }
 
         DayOfWeek dayOfWeek = dayOfWeekConverter.toDayOfWeek(request.getBedDayOfWeekList());
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: create
+          auto: update
         default_batch_fetch_size: 1000
 
 fcm:


### PR DESCRIPTION
## Description
취침 알림 시간 설정 버그를 수정합니다.

## Changes
### 변경 사항 제목
- [x] UserServiceImpl 의 setBedTime 메소드 수정
## API
| URL                | method | Usage                | Authorization Needed |
| ------------------ | ------ | -------------------- | -------------------- |
|/user/bedtime/alarm     | POST| 알림 시간 설정| Yes                    |
## Additional context
버그의 원인은 JPA 레포지토리의 delete 메소드에 null 엔티티가 전달되는 에러입니다. 

dayOfWeekRepository.delete(user.getBedDayOfWeek()); 에서 유저의 BedDayOfWeek이 null인 경우를 생각치 못하고 구현한 실수입니다.

if문으로 null이 아닐 때만 delete 메소드를 실행하도록 수정하였습니다.