### PR TITLE
feat, refactor: 애플 소셜로그인 엑세스 토큰 재발급 및 리프레시 토큰 쿠키 사용 해제

### DIFF
--- a/src/main/java/go/alarm/login/dto/ExtendLoginRequest.java
+++ b/src/main/java/go/alarm/login/dto/ExtendLoginRequest.java
@@ -1,0 +1,14 @@
+package go.alarm.login.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ExtendLoginRequest {
+
+    private String refreshToken;
+
+}

--- a/src/main/java/go/alarm/login/dto/LoginTokenResponse.java
+++ b/src/main/java/go/alarm/login/dto/LoginTokenResponse.java
@@ -1,5 +1,6 @@
 package go.alarm.login.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +12,8 @@ import lombok.NoArgsConstructor;
 public class LoginTokenResponse {
 
     private String accessToken;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL) // 어노테이션이 적용된 필드가 null인 경우, JSON 응답에서 해당 필드는 제외
     private String refreshToken;
 
     public LoginTokenResponse(String accessToken) {

--- a/src/main/java/go/alarm/login/infrastructure/JwtProvider.java
+++ b/src/main/java/go/alarm/login/infrastructure/JwtProvider.java
@@ -48,7 +48,6 @@ public class JwtProvider {
         this.refreshExpirationTime = refreshExpirationTime;
     }
 
-
     /**
     * 로그인 시 사용자 식별자(subject)를 받아 액세스 토큰과 리프레시 토큰을 생성
     * */
@@ -61,6 +60,12 @@ public class JwtProvider {
         return new UserTokens(refreshToken, accessToken);
     }
 
+    /**
+     * 새로운 액세스 토큰을 생성
+     * */
+    public String regenerateAccessToken(final String subject) {
+        return createToken(subject, accessExpirationTime);
+    }
 
     /**
     * 실제 JWT 토큰을 생성하는 메서드
@@ -141,12 +146,7 @@ public class JwtProvider {
             .parseClaimsJws(token); // 주어진 토큰을 파싱하고 서명을 검증
     }
 
-    /**
-     * 새로운 액세스 토큰을 생성
-     * */
-    public String regenerateAccessToken(final String subject) {
-        return createToken(subject, accessExpirationTime);
-    }
+
 
     /**
      * 리프레시 토큰은 유효하고 액세스 토큰은 만료된 상황인지 확인

--- a/src/main/java/go/alarm/login/presentation/LoginController.java
+++ b/src/main/java/go/alarm/login/presentation/LoginController.java
@@ -3,6 +3,7 @@ package go.alarm.login.presentation;
 
 import go.alarm.login.domain.UserTokens;
 import go.alarm.global.response.SuccessResponse;
+import go.alarm.login.dto.ExtendLoginRequest;
 import go.alarm.login.dto.LoginTokenResponse;
 import go.alarm.login.service.LoginService;
 import go.alarm.login.dto.LoginRequest;
@@ -47,12 +48,12 @@ public class LoginController {
 
     @PostMapping("/accesstoken")
     public SuccessResponse<LoginTokenResponse> extendLogin(
-        @RequestBody final String refreshToken,
+        @RequestBody final ExtendLoginRequest request,
         @RequestHeader("Authorization") final String authorizationHeader // Authorization 헤더 값 (Bearer 토큰을 포함한 엑세스 토큰)
     ) {
-        log.warn("컨트롤러단(/accesstoken) 리프레시 토큰 >>" + refreshToken);
+        log.warn("컨트롤러단(/accesstoken) 리프레시 토큰 >>" + request.getRefreshToken());
         log.warn("컨트롤러단(/accesstoken) 엑세스 토큰 >>" + authorizationHeader);
-        final String renewalAccessToken = loginService.renewalAccessToken(refreshToken, authorizationHeader);
+        final String renewalAccessToken = loginService.renewalAccessToken(request.getRefreshToken(), authorizationHeader);
         return new SuccessResponse<>(new LoginTokenResponse(renewalAccessToken));
     }
 


### PR DESCRIPTION
## Description
엑세스 토큰이 만료되었을 때 재발급 받는 API를 구현합니다.

리프레시 토큰을 쿠키가 아닌 클라이언트 로컬에 저장해둡니다.

## Changes
### 변경 사항 제목
- [x] 엑세스 토큰 재발급 API 구현
- [x] 엑세스 토큰 재발급 API 에러 수정
- [x] 쿠키 사용 해제
## API
| URL                | method | Usage                | Authorization Needed |
| ------------------ | ------ | -------------------- | -------------------- |
| /accesstoken       | POST| 엑세스 토큰 재발급| Yes                    |

