### PR TITLE
[Feat, Refactor] 메인페이지 조회 API 컨트롤러 메소드의 사용자 인증 로직 구현, LoginArgumentResolver 수정

### DIFF
--- a/src/main/java/go/alarm/auth/UesrOnly.java
+++ b/src/main/java/go/alarm/auth/UesrOnly.java
@@ -1,0 +1,11 @@
+package go.alarm.auth;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface UesrOnly {
+}

--- a/src/main/java/go/alarm/auth/UserOnlyChecker.java
+++ b/src/main/java/go/alarm/auth/UserOnlyChecker.java
@@ -1,0 +1,31 @@
+package go.alarm.auth;
+
+import static go.alarm.global.response.ResponseCode.INVALID_AUTHORITY;
+
+import go.alarm.auth.domain.Accessor;
+import go.alarm.global.response.exception.AuthException;
+import java.util.Arrays;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+/**
+ * @UserOnly 어노테이션이 붙은 메서드가 호출될 때마다 자동으로 권한 검사를 수행합니다.
+ * 메서드의 인자 중 Accessor 타입이면서 isUser()가 true인 객체가 있는지 확인합니다.
+ * 조건을 만족하는 객체가 없으면 AuthException을 발생시켜 권한이 없음을 알립니다.
+ * */
+@Aspect
+@Component
+public class UserOnlyChecker {
+
+    @Before("@annotation(go.alarm.auth.UesrOnly)") // @MemberOnly 어노테이션이 붙은 메서드가 실행되기 전에 호출
+    public void check(final JoinPoint joinPoint) {
+        Arrays.stream(joinPoint.getArgs()) // 메서드의 모든 인자를 스트림으로 변환
+            .filter(Accessor.class::isInstance) // Accessor 타입의 인자만 필터링
+            .map(Accessor.class::cast) // 필터링된 객체를 Accessor로 캐스팅(형 변환)
+            .filter(Accessor::isUser)
+            .findFirst()// 조건을 만족하는 첫 번째 Accessor 객체를 찾음
+            .orElseThrow(() -> new AuthException(INVALID_AUTHORITY));
+    }
+}

--- a/src/main/java/go/alarm/auth/domain/Accessor.java
+++ b/src/main/java/go/alarm/auth/domain/Accessor.java
@@ -2,6 +2,10 @@ package go.alarm.auth.domain;
 
 import lombok.Getter;
 
+/**
+ * LoginArgumentResolver 클래스의 resolveArgument 메서드가 반환한 Accessor 객체가 컨트롤러의 파라미터로 전달됩니다.
+ * 이러한 Accessor를 저장할 객체입니다.
+ * */
 @Getter
 public class Accessor {
 
@@ -13,8 +17,8 @@ public class Accessor {
         this.authority = authority;
     }
 
-    public static Accessor member(final Long userId) {
-        return new Accessor(userId, Authority.MEMBER);
+    public static Accessor user(final Long userId) {
+        return new Accessor(userId, Authority.USER);
     }
 
     public static Accessor admin(final Long userId) {
@@ -26,8 +30,8 @@ public class Accessor {
     }
 
 
-    public boolean isMember() {
-        return Authority.MEMBER.equals(authority);
+    public boolean isUser() {
+        return Authority.USER.equals(authority);
     }
 
     public boolean isAdmin() {

--- a/src/main/java/go/alarm/auth/domain/Authority.java
+++ b/src/main/java/go/alarm/auth/domain/Authority.java
@@ -1,7 +1,7 @@
 package go.alarm.auth.domain;
 
 public enum Authority {
-    MEMBER,
+    USER,
     ADMIN,
     MASTER
 }

--- a/src/main/java/go/alarm/home/presentation/HomeController.java
+++ b/src/main/java/go/alarm/home/presentation/HomeController.java
@@ -1,5 +1,8 @@
 package go.alarm.home.presentation;
 
+import go.alarm.auth.Auth;
+import go.alarm.auth.UesrOnly;
+import go.alarm.auth.domain.Accessor;
 import go.alarm.global.response.SuccessResponse;
 import go.alarm.home.dto.response.HomeResponse;
 import go.alarm.home.service.HomeService;
@@ -9,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,13 +25,14 @@ public class HomeController {
         private final HomeService homeService;
 
         @GetMapping("/home")
+        @UesrOnly
         @Operation(summary = "메인페이지 조회 API", description = "메인페이지를 조회합니다.")
         @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",description = "OK, 성공입니다.")
         })
-        public SuccessResponse<HomeResponse.HomeDTO> getMainPage(@RequestHeader(name = "userId") Long userId) {
-            //소셜로그인이 들어가면 위 헤더 부분이 사라지고 토큰으로 유저를 구분해야함.
+        public SuccessResponse<HomeResponse.HomeDTO> getMainPage(
+            @Auth final Accessor accessor){
 
-            return new SuccessResponse<>(homeService.getHome(userId));
+                return new SuccessResponse<>(homeService.getHome(accessor.getUserId()));
         }
 }

--- a/src/main/java/go/alarm/login/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/go/alarm/login/domain/repository/RefreshTokenRepository.java
@@ -1,12 +1,10 @@
 package go.alarm.login.domain.repository;
 
 import go.alarm.login.domain.RefreshToken;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+
+    RefreshToken findByUserId(Long userId);
 
 }

--- a/src/main/java/go/alarm/login/infrastructure/JwtProvider.java
+++ b/src/main/java/go/alarm/login/infrastructure/JwtProvider.java
@@ -26,7 +26,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
-* JWT 토큰을 생성하고 검증
+* JWT 토큰을 생성하고 검증합니다.
 * */
 @Slf4j
 @Component
@@ -51,8 +51,9 @@ public class JwtProvider {
     }
 
     /**
-    * 로그인 시 사용자 식별자(subject)를 받아 액세스 토큰과 리프레시 토큰을 생성
-    * */
+     * 로그인 시 사용자 식별자(subject)를 받아 액세스 토큰과 리프레시 토큰을 생성
+     * subject는 userId를 사용
+     *  */
     public UserTokens generateLoginToken(final String subject) {
 
         final String refreshToken = createToken(EMPTY_SUBJECT, refreshExpirationTime);
@@ -93,20 +94,10 @@ public class JwtProvider {
     }
 
     /**
-     * 액세스 토큰과 리프레시 토큰의 유효성을 검사
-     * */
-    public void validateTokens(final UserTokens userTokens) {
-        validateRefreshToken(userTokens.getRefreshToken());
-        validateAccessToken(userTokens.getAccessToken());
-    }
-
-    /**
      * 리프레시 토큰 유효성 검사
      * */
-    private void validateRefreshToken(final String refreshToken) {
+    public void validateRefreshToken(final String refreshToken) {
         try {
-            log.warn("validateRefreshToken 메소드에서의(JwtProvider) 리프레시 토큰 >>" + refreshToken);
-            
             parseToken(refreshToken);
         } catch (final ExpiredJwtException e) {
             throw new ExpiredPeriodJwtException(EXPIRED_PERIOD_REFRESH_TOKEN);
@@ -118,7 +109,7 @@ public class JwtProvider {
     /**
      * 엑세스 토큰 유효성 검사
      * */
-    private void validateAccessToken(final String accessToken) {
+    public void validateAccessToken(final String accessToken) {
         try {
             parseToken(accessToken);
         } catch (final ExpiredJwtException e) {

--- a/src/main/java/go/alarm/login/service/LoginServiceImpl.java
+++ b/src/main/java/go/alarm/login/service/LoginServiceImpl.java
@@ -44,6 +44,9 @@ public class LoginServiceImpl implements LoginService{
             oauthUserInfo.getSocialLoginId(),
             oauthUserInfo.getEmail()
         );
+        RefreshToken refreshTokenObject = refreshTokenRepository.findByUserId(user.getId());
+        removeRefreshToken(refreshTokenObject.getRefreshToken()); // 기존에 존재하던 리프레시 토큰 제거
+
         final UserTokens userTokens = jwtProvider.generateLoginToken(user.getId().toString());
         // UserTokens에서 엑세스, 리프레쉬 토큰 가져와서 유저 필드에 저장
         log.warn("서비스단(/login) 리프레시 토큰 >>" + userTokens.getRefreshToken());


### PR DESCRIPTION
## Description
API 컨트롤러 메소드의 사용자 인증 로직 구현합니다.

사용자 인증이 필요한  API의 컨트롤러에 사용자 인증 처리 어노테이션을 추가합니다.

LoginArgumentResolver 의 resolveArgument 메소드에서 리프레시 토큰을 가져오는 방식을 수정합니다.

## Changes
### 변경 사항 제목
- [ ] 사용자 인증이 필요한 API 컨트롤러에 사용자 인증 추가
- [x] 메인페이지 조회 API 컨트롤러에 사용자 인증 추가
- [x] resolveArgument 메소드에서 리프레시 토큰을 가져오는 방식을 수정

