### PR TITLE
[Fix[ 회원탈퇴시 애플 계정과의 연동 해제

### DIFF
--- a/src/main/java/go/alarm/global/response/ResponseCode.java
+++ b/src/main/java/go/alarm/global/response/ResponseCode.java
@@ -62,6 +62,7 @@ public enum ResponseCode {
     EXPIRED_PERIOD_ACCESS_TOKEN(false, 9104, "기한이 만료된 AccessToken입니다."),
     FAIL_TO_VALIDATE_TOKEN(false, 9105, "토큰 유효성 검사 중 오류가 발생했습니다."),
     NOT_FOUND_REFRESH_TOKEN(false, 9106, "RefreshToken이 null이거나 빈 문자열입니다."),
+    FAIL_REVOKE_APPLE_TOKEN(false, 9106, "애플 토큰 삭제를 실패했습니다."),
     INVALID_AUTHORITY(false, 9201, "해당 요청에 대한 접근 권한이 없습니다.");
 
     private final boolean isSuccess;

--- a/src/main/java/go/alarm/login/domain/OauthProvider.java
+++ b/src/main/java/go/alarm/login/domain/OauthProvider.java
@@ -8,4 +8,6 @@ public interface OauthProvider {
 
     boolean is(String name);
     OauthUserInfo getUserInfo(String code);
+
+    void revokeToken(String socialLoginId);
 }

--- a/src/main/java/go/alarm/login/infrastructure/oauthuserinfo/AppleUserInfo.java
+++ b/src/main/java/go/alarm/login/infrastructure/oauthuserinfo/AppleUserInfo.java
@@ -14,7 +14,7 @@ public class    AppleUserInfo implements OauthUserInfo {
     private String socialLoginId; // 애플에서 제공하는 고유한 사용자 ID,  JWT의 'sub' 클레임에서 제공됨
 
     @JsonProperty("email")
-    private String email; // 애플에서는 이메일을 제공, 사용자가 거부하면 null이 됨.
+    private String email; // 애플에서는 이메일을 제공, 사용자가 거부하면 애플에서 생성한 임의의 이메일이 됨.
 
     @Override
     public String getSocialLoginId() {

--- a/src/main/java/go/alarm/login/presentation/LoginController.java
+++ b/src/main/java/go/alarm/login/presentation/LoginController.java
@@ -72,11 +72,17 @@ public class LoginController {
 
     }
 
-
-    @DeleteMapping("/account")
+    /**
+     * 회원탈퇴 API입니다.
+     * 현재는 애플로그인 회원탈퇴만 구현했습니다.
+     * 추후 Resource Server가 추가될 수도 있기에 {provider}로 받아옵니다.
+     * */
+    @DeleteMapping("/account/{provider}")
     @UesrOnly
-    public SuccessResponse<Void> deleteAccount(@Auth final Accessor accessor) {
-        loginService.deleteAccount(accessor.getUserId());
+    public SuccessResponse<Void> deleteAccount(
+        @PathVariable final String provider,
+        @Auth final Accessor accessor) {
+        loginService.deleteAccount(accessor.getUserId(), provider);
         return new SuccessResponse<>();
     }
 

--- a/src/main/java/go/alarm/login/service/LoginService.java
+++ b/src/main/java/go/alarm/login/service/LoginService.java
@@ -9,5 +9,5 @@ public interface LoginService {
 
     void removeRefreshToken(final String refreshToken);
 
-    void deleteAccount(final Long memberId);
+    void deleteAccount(final Long memberId, String providerName);
 }

--- a/src/main/java/go/alarm/login/service/LoginServiceImpl.java
+++ b/src/main/java/go/alarm/login/service/LoginServiceImpl.java
@@ -104,8 +104,11 @@ public class LoginServiceImpl implements LoginService{
     }
 
     @Override
-    public void deleteAccount(final Long userId) {
+    public void deleteAccount(final Long userId,final String providerName) {
         User user = userRepository.findById(userId).get();
+        OauthProvider provider = oauthProviders.mapping(providerName);
+
+        provider.revokeToken(user.getSocialLoginId());
 
         WakeUpDayOfWeek bedDayOfWeek = user.getBedDayOfWeek();
         if (bedDayOfWeek != null) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,7 +49,7 @@ oauth2:
         id: ${TEAM_ID}
       key:
         id: ${KEY_ID}
-        path: file:./AuthKey_${KEY_ID}.p8
+        path: ./AuthKey_${KEY_ID}.p8
 
 # 알람
 fcm:


### PR DESCRIPTION
## Description
회원탈퇴시 애플 계정과의 연동 해제

## Changes
### 변경 사항 제목
- [x] AppleOauthProvider에 애플 토큰 삭제 로직 추가
- [x] LoginController의 회원탈퇴 API URI 수정
- [x] application.yml key.path값 수정
- [x] ResponseCode에 에러 코드 추가
## API
| URL                | method | Usage                | Authorization Needed |
| ------------------ | ------ | -------------------- | -------------------- |
| /account/{provider}      | DLETE| 애플 회원 탈퇴| Yes              |
## Additional context
추가적인 내용

Closes #이슈번호