### PR TITLE
fix: 애플 회원탈퇴 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // 사용 중인 JSON 파서에 맞는 것을 선택
 
+	//implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
+
 	// S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 

--- a/src/main/java/go/alarm/global/response/ResponseCode.java
+++ b/src/main/java/go/alarm/global/response/ResponseCode.java
@@ -63,6 +63,8 @@ public enum ResponseCode {
     FAIL_TO_VALIDATE_TOKEN(false, 9105, "토큰 유효성 검사 중 오류가 발생했습니다."),
     NOT_FOUND_REFRESH_TOKEN(false, 9106, "RefreshToken이 null이거나 빈 문자열입니다."),
     FAIL_REVOKE_APPLE_TOKEN(false, 9106, "애플 토큰 삭제를 실패했습니다."),
+    FAIL_GET_APPLE_TOKEN(false, 9106, "애플 리프레시 토큰 발급을 실패했습니다."),
+    FAIL_GETTING_APPLE_TOKEN(false, 9106, "애플 리프레시 토큰 발급 도중 에러가 발생했습니다."),
     INVALID_AUTHORITY(false, 9201, "해당 요청에 대한 접근 권한이 없습니다.");
 
     private final boolean isSuccess;

--- a/src/main/java/go/alarm/group/domain/UserGroup.java
+++ b/src/main/java/go/alarm/group/domain/UserGroup.java
@@ -1,7 +1,6 @@
 package go.alarm.group.domain;
 
 import go.alarm.global.BaseEntity;
-import go.alarm.group.domain.Group;
 import go.alarm.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/go/alarm/login/LoginArgumentResolver.java
+++ b/src/main/java/go/alarm/login/LoginArgumentResolver.java
@@ -1,5 +1,6 @@
 package go.alarm.login;
 
+import static go.alarm.global.response.ResponseCode.EXPIRED_PERIOD_REFRESH_TOKEN;
 import static go.alarm.global.response.ResponseCode.INVALID_REFRESH_TOKEN;
 import static go.alarm.global.response.ResponseCode.INVALID_REQUEST;
 import static go.alarm.global.response.ResponseCode.INVALID_USER;
@@ -85,8 +86,13 @@ public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
     private String extractRefreshToken(final Long userId){
 
         RefreshToken refreshTokenObject = refreshTokenRepository.findByUserId(userId);
+        String refreshToken;
 
-        String refreshToken = refreshTokenObject.getRefreshToken();
+        if(refreshTokenObject == null){
+            throw new RefreshTokenException(EXPIRED_PERIOD_REFRESH_TOKEN);
+        }else {
+            refreshToken = refreshTokenObject.getRefreshToken();
+        }
 
         if (refreshToken == null || refreshToken.isEmpty()) { // 토큰이 null이거나 빈 문자열인지 확인
             throw new RefreshTokenException(NOT_FOUND_REFRESH_TOKEN);

--- a/src/main/java/go/alarm/login/domain/AppleRefreshToken.java
+++ b/src/main/java/go/alarm/login/domain/AppleRefreshToken.java
@@ -1,0 +1,28 @@
+package go.alarm.login.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+ * AppleRefreshToken을 저장하는 엔티티
+ * */
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AppleRefreshToken {
+    
+    @Id
+    private String refreshToken;
+
+    @Column(nullable = false)
+    private Long userId;
+
+}

--- a/src/main/java/go/alarm/login/domain/OauthProvider.java
+++ b/src/main/java/go/alarm/login/domain/OauthProvider.java
@@ -9,5 +9,7 @@ public interface OauthProvider {
     boolean is(String name);
     OauthUserInfo getUserInfo(String code);
 
-    void revokeToken(String socialLoginId);
+    Boolean revokeToken(Long userId, String appleRefreshToken);
+
+    String getRefreshToken(String authorizationCode);
 }

--- a/src/main/java/go/alarm/login/domain/repository/AppleRefreshTokenRepository.java
+++ b/src/main/java/go/alarm/login/domain/repository/AppleRefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package go.alarm.login.domain.repository;
+
+import go.alarm.login.domain.AppleRefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppleRefreshTokenRepository extends JpaRepository<AppleRefreshToken, String> {
+
+    AppleRefreshToken findByUserId(Long userId);
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/go/alarm/login/dto/LoginRequest.java
+++ b/src/main/java/go/alarm/login/dto/LoginRequest.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LoginRequest {
 
+    private String identityToken;
     private String code;
 }
 

--- a/src/main/java/go/alarm/login/infrastructure/oauthuserinfo/AppleUserInfo.java
+++ b/src/main/java/go/alarm/login/infrastructure/oauthuserinfo/AppleUserInfo.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
 @AllArgsConstructor
-public class    AppleUserInfo implements OauthUserInfo {
+public class AppleUserInfo implements OauthUserInfo {
 
     @JsonProperty("sub")
     private String socialLoginId; // 애플에서 제공하는 고유한 사용자 ID,  JWT의 'sub' 클레임에서 제공됨

--- a/src/main/java/go/alarm/login/presentation/LoginController.java
+++ b/src/main/java/go/alarm/login/presentation/LoginController.java
@@ -40,7 +40,7 @@ public class LoginController {
         @RequestBody final LoginRequest request,
         final HttpServletResponse response
     ) {
-        final UserTokens userTokens = loginService.login(provider, request.getCode());
+        final UserTokens userTokens = loginService.login(provider, request.getIdentityToken(),request.getCode());
         log.warn("컨트롤러단(/login) 리프레시 토큰 >>" + userTokens.getRefreshToken());
         log.warn("컨트롤러단(/login) 엑세스 토큰 >>" + userTokens.getAccessToken());
 

--- a/src/main/java/go/alarm/login/presentation/LoginConverter.java
+++ b/src/main/java/go/alarm/login/presentation/LoginConverter.java
@@ -1,5 +1,6 @@
 package go.alarm.login.presentation;
 
+import go.alarm.login.domain.AppleRefreshToken;
 import go.alarm.user.domain.User;
 import go.alarm.login.domain.RefreshToken;
 import go.alarm.user.domain.UserState;
@@ -18,6 +19,14 @@ public class LoginConverter {
     public static RefreshToken toRefreshToken(final String refreshToken, final Long userId){
 
         return RefreshToken.builder()
+            .refreshToken(refreshToken)
+            .userId(userId)
+            .build();
+    }
+
+    public static AppleRefreshToken toAppleRefreshToken(final String refreshToken, final Long userId){
+
+        return AppleRefreshToken.builder()
             .refreshToken(refreshToken)
             .userId(userId)
             .build();

--- a/src/main/java/go/alarm/login/service/LoginService.java
+++ b/src/main/java/go/alarm/login/service/LoginService.java
@@ -3,7 +3,7 @@ package go.alarm.login.service;
 import go.alarm.login.domain.UserTokens;
 
 public interface LoginService {
-    UserTokens login(final String providerName, final String code);
+    UserTokens login(final String providerName, final String identityToken, final String code);
 
     String renewalAccessToken(final String refreshTokenRequest, final String authorizationHeader);
 


### PR DESCRIPTION
## Description
해당 PR에 대한 설명
## Changes
### 변경 사항 제목
- [x] 애플 소셜로그인 과정에서 리프레시 토큰 받아오도록 수정
- [x] 애플 회원탈퇴 요청시 애플의 리프레시 토큰과 함께 요청하도록 수정
## API
| URL                | method | Usage                | Authorization Needed |
| ------------------ | ------ | -------------------- | -------------------- |
| /account/{provider}      | DLETE| 애플 회원 탈퇴| Yes              |
## Additional context
